### PR TITLE
Avoid hinting lookup could be an impure function

### DIFF
--- a/_posts/2015-01-26-haskell-io.markdown
+++ b/_posts/2015-01-26-haskell-io.markdown
@@ -83,8 +83,8 @@ If you have a dictionary lookup function which takes a key and returns a result 
 lookup :: String -> Maybe String
 {% endhighlight %}
 
-We don't specify the dictionary with this function, we just assume
-it's in the environment somewhere for simplicity.
+We don't specify the dictionary as an argument, we just assume
+the function has its own built in dictionary for simplicity.
 
 `Maybe a` is a type with two potential values: it's either `Nothing`
 or `Just a`, where `a` is a type we haven't specified. In this example


### PR DESCRIPTION
Just a take-it-or-leave suggestion, but from a teaching perspective I wonder if you're better off avoiding mentioning 'the environment' here? I could imagine very new Haskellers believing `lookup` was going to go out and look up the string dynamically somewhere, which of course is exactly what it can't do.